### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,11 @@
+version: 2
+jobs:
+  build:
+    docker:
+    - image: circleci/golang:1.10
+    working_directory: /go/src/github.com/buoyantio/bb
+    steps:
+    - checkout
+    - run: bin/dep ensure -vendor-only
+    - run: go vet -tests -all ./...
+    - run: go test -race -v ./...


### PR DESCRIPTION
Adds a basic CircleCI config that runs `go vet` and `go test`. Once this merges to master I'll protect the master branch so that other PRs aren't mergeable until they pass CI.

Example of a passing test run on this branch:
https://circleci.com/gh/BuoyantIO/bb/3

Fixes #2.