### PR TITLE
Add precheck.sh script, badges in readme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,5 +7,4 @@ jobs:
     steps:
     - checkout
     - run: bin/dep ensure -vendor-only
-    - run: go vet -tests -all ./...
-    - run: go test -race -v ./...
+    - run: bin/precheck.sh

--- a/README.md
+++ b/README.md
@@ -1,30 +1,33 @@
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![CircleCI](https://circleci.com/gh/BuoyantIO/bb.svg?style=shield)](https://circleci.com/gh/BuoyantIO/bb)
+
 # bb
 
-Building Blocks or `bb` is a tool that can simulate many of the typical scenarios 
+Building Blocks or `bb` is a tool that can simulate many of the typical scenarios
 of a cloud-native Service-Oriented Architecture based on microservices.
 
 ## Using `bb`
-`bb` publishes a single container, `buoyantio/bb:v0.0.1`. Instances of this 
-container receive and return a simple message, described by the protobuf schema 
-[in this repository](api.proto). This known interface allows for `bb` 
-containers to be arranged in many different ways, just like building a structure 
+`bb` publishes a single container, `buoyantio/bb:v0.0.1`. Instances of this
+container receive and return a simple message, described by the protobuf schema
+[in this repository](api.proto). This known interface allows for `bb`
+containers to be arranged in many different ways, just like building a structure
 using LEGO blocks.
 
-The best way to find out about `bb` features is by using the `--help` command and 
+The best way to find out about `bb` features is by using the `--help` command and
 checking out the self-contained documentation.
 
 ### Running locally
-If you want to run `bb` locally, outside a Kubernetes cluster or Docker, you need 
-to build a binary for your environment. The usual way to go about this is using Go's 
+If you want to run `bb` locally, outside a Kubernetes cluster or Docker, you need
+to build a binary for your environment. The usual way to go about this is using Go's
 standard build tools. From this repository's root, run:
 
     $ mkdir -p target && go build -o target/bb .
 
-This will create a `bb` binary in the `target` directory. You can run this on your 
-computer but, unless you use Linux, you won't be able to use this same binary on 
+This will create a `bb` binary in the `target` directory. You can run this on your
+computer but, unless you use Linux, you won't be able to use this same binary on
 Docker or Kubernetes.
 
-As an example of how to use `bb` on your computer, let's create a simple two-service 
+As an example of how to use `bb` on your computer, let's create a simple two-service
 setup. Open a terminal and type in the following:
 
     $  target/bb terminus --grpc-server-port 9090 --response-text BANANA
@@ -38,20 +41,20 @@ Now, on a third terminal, type this and you should see a similar response:
     $ curl localhost:8080
     {"requestUid":"in:http-sid:point-to-point-channel-grpc:-1-h1:8080-387107000","payload":"BANANA"}
 
-The first command you typed created a gRPC server on port 9090 following the [terminus strategy](strategies/terminus.go), 
+The first command you typed created a gRPC server on port 9090 following the [terminus strategy](strategies/terminus.go),
 which will return the payload defined as the `--response-text` argument for any valid request.
 
-The second command creates an HTTP 1.1 server on port 8080 following the 
-[point-to-point channel strategy](strategies/point_to_point_channel.go), and has the gRPC server 
-previously defined as its downstream. It will receive any HTTP 1.1 request, convert it to gRPC, 
-and forward it to the downstream server. It will also get the gRPC response from the server, convert 
+The second command creates an HTTP 1.1 server on port 8080 following the
+[point-to-point channel strategy](strategies/point_to_point_channel.go), and has the gRPC server
+previously defined as its downstream. It will receive any HTTP 1.1 request, convert it to gRPC,
+and forward it to the downstream server. It will also get the gRPC response from the server, convert
 it to JSON-over-HTTP, and return to its client.
 
 ## Running on Kubernetes
-Although `bb` can be useful to test things locally as described above, its main use case is to create 
+Although `bb` can be useful to test things locally as described above, its main use case is to create
 complicated environments inside Kubernetes clusters.
 
-To use `bb` with Kubernetes, the first step you need to take is to publish its Docker image to your 
+To use `bb` with Kubernetes, the first step you need to take is to publish its Docker image to your
 Kubernetes cluster. Here we will be using a local Minikube installation to demonstrate its use.
 
 First, make sure that Minikube is running:
@@ -61,7 +64,7 @@ First, make sure that Minikube is running:
       cluster: Running
       kubectl: Correctly Configured: pointing to minikube-vm at 192.168.99.100
 
-Now, make sure that your Docker environment variables are set to use Minikube as the Docker repository 
+Now, make sure that your Docker environment variables are set to use Minikube as the Docker repository
 for images:
 
     $ eval "$(minikube docker-env)"
@@ -83,17 +86,17 @@ A test run using the Docker CLI should return usage information and confirm that
      $ docker run buoyantio/bb:v0.0.1
     Building Blocks or `bb` is a tool that can simulate many of the typical scenarios of a cloud-native Service-Oriented Architecture based on microservices.
 
-    
+
     Usage:
       bb [command]
-    
+
     Available Commands:
       broadcast-channel      Forwards the request to all downstream services.
       help                   Help about any command
       http-egress            Receives a request, makes a HTTP(S) call to a specified URL and return the body of the response
       point-to-point-channel Forwards the request to one and only one downstream service.
       terminus               Receives the request and returns a pre-defined response
-    
+
     Flags:
           --downstream-timeout duration          timeout to use when making downstream connections. (default 1m0s)
           --fire-and-forget                      do not wait for a response when contacting downstream services.
@@ -106,11 +109,11 @@ A test run using the Docker CLI should return usage information and confirm that
           --log-level string                     log level, must be one of: panic, fatal, error, warn, info, debug (default "debug")
           --percent-failure int                  percentage of requests that this service will automatically fail
           --sleep-in-millis int                  amount of milliseconds to wait before actually start processing as request
-    
+
     Use "bb [command] --help" for more information about a command.
 
-To build the exact same scenario we had above, but for Kubernetes, you can deploy the should have 
-a YAML configuration like the one in our [examples directory](). You can deploy it to your Kubernetes 
+To build the exact same scenario we had above, but for Kubernetes, you can deploy the should have
+a YAML configuration like the one in our [examples directory](). You can deploy it to your Kubernetes
 cluster by running:
 
     $ kubectl apply -f examples/bb-readme/application.yaml

--- a/bin/precheck.sh
+++ b/bin/precheck.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eu
+
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir="$( cd "$bindir/.." && pwd )"
+cd "$rootdir"
+
+echo "====================== running go vet  ======================"
+go vet -v -tests -all ./...
+
+echo ""
+echo "====================== running go test ======================"
+go test -race -v ./...


### PR DESCRIPTION
Followup to #4. Add a script for running vet and test, and use that script in our CircleCI config. As part of this change I also added CI and License badges in the README. My editor stripped trailing whitespace in that file, but I can revert that if it's annoying.