### PR TITLE
Better handling of contexts/deadlines/timeouts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## In the next release...
+
+* Better handling of contexts/deadlines/timeouts
+
 ## v0.0.5
 
 * Fix gRPC clients to honor `downstream-timeout`.

--- a/README.md
+++ b/README.md
@@ -98,19 +98,19 @@ A test run using the Docker CLI should return usage information and confirm that
       terminus               Receives the request and returns a pre-defined response
 
     Flags:
-          --downstream-timeout duration          timeout to use when making downstream connections. (default 1m0s)
-          --fire-and-forget                      do not wait for a response when contacting downstream services.
-          --grpc-downstream-server stringSlice   list of servers (hostname:port) to send messages to using gRPC, can be repeated
-          --grpc-proxy string                    optional proxy to route gRPC requests
-          --grpc-server-port int                 port to bind a gRPC server to (default -1)
-          --h1-downstream-server stringSlice     list of servers (protocol://hostname:port) to send messages to using HTTP 1.1, can be repeated
-          --h1-server-port int                   port to bind a HTTP 1.1 server to (default -1)
-      -h, --help                                 help for bb
-          --id string                            identifier for this container
-          --log-level string                     log level, must be one of: panic, fatal, error, warn, info, debug (default "info")
-          --percent-failure int                  percentage of requests that this service will automatically fail
-          --sleep-in-millis int                  amount of milliseconds to wait before actually start processing a request
-          --terminate-after int                  terminate the process after this many requests
+          --downstream-timeout duration      timeout to use when making downstream connections and requests. (default 1m0s)
+          --fire-and-forget                  do not wait for a response when contacting downstream services.
+          --grpc-downstream-server strings   list of servers (hostname:port) to send messages to using gRPC, can be repeated
+          --grpc-proxy string                optional proxy to route gRPC requests
+          --grpc-server-port int             port to bind a gRPC server to (default -1)
+          --h1-downstream-server strings     list of servers (protocol://hostname:port) to send messages to using HTTP 1.1, can be repeated
+          --h1-server-port int               port to bind a HTTP 1.1 server to (default -1)
+      -h, --help                             help for bb
+          --id string                        identifier for this container
+          --log-level string                 log level, must be one of: panic, fatal, error, warn, info, debug (default "info")
+          --percent-failure int              percentage of requests that this service will automatically fail
+          --sleep-in-millis int              amount of milliseconds to wait before actually start processing a request
+          --terminate-after int              terminate the process after this many requests
 
     Use "bb [command] --help" for more information about a command.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,6 @@ func init() {
 	RootCmd.PersistentFlags().StringSliceVar(&config.GRPCDownstreamServers, "grpc-downstream-server", []string{}, "list of servers (hostname:port) to send messages to using gRPC, can be repeated")
 	RootCmd.PersistentFlags().StringVar(&config.GRPCProxy, "grpc-proxy", "", "optional proxy to route gRPC requests")
 	RootCmd.PersistentFlags().StringSliceVar(&config.H1DownstreamServers, "h1-downstream-server", []string{}, "list of servers (protocol://hostname:port) to send messages to using HTTP 1.1, can be repeated")
-	RootCmd.PersistentFlags().DurationVar(&config.DownstreamConnectionTimeout, "downstream-timeout", time.Minute*1, "timeout to use when making downstream connections.")
+	RootCmd.PersistentFlags().DurationVar(&config.DownstreamTimeout, "downstream-timeout", time.Minute*1, "timeout to use when making downstream connections and requests.")
 	RootCmd.PersistentFlags().StringVar(&logLevel, "log-level", log.InfoLevel.String(), "log level, must be one of: panic, fatal, error, warn, info, debug")
 }

--- a/protocols/grpc.go
+++ b/protocols/grpc.go
@@ -97,7 +97,6 @@ func NewGrpcClientsIfConfigured(config *service.Config) ([]service.Client, error
 			clientID = config.GRPCProxy + " / " + serverURL
 		}
 
-		// we can throw away the CancelFunc because we use `grpc.WithBlock()` below
 		ctx, cancel := context.WithTimeout(context.Background(), config.DownstreamTimeout)
 		defer cancel()
 

--- a/protocols/http.go
+++ b/protocols/http.go
@@ -55,6 +55,8 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	log.Debugf("Received HTTP request [%s] [%+v] Context [%+v] Body [%+v]", protoReq.RequestUID, req, req.Context(), protoReq)
+
 	protoResponse, err := h.serviceHandler.Handle(req.Context(), &protoReq)
 	if err != nil {
 		dealWithErrorDuringHandling(w, fmt.Errorf("error handling http request: %v", err))
@@ -79,7 +81,7 @@ func (c *httpClient) Close() error { return nil }
 
 func (c *httpClient) GetID() string { return c.id }
 
-func (c *httpClient) Send(req *pb.TheRequest) (*pb.TheResponse, error) {
+func (c *httpClient) Send(_ context.Context, req *pb.TheRequest) (*pb.TheResponse, error) {
 	json, err := marshallProtobufToJSON(req)
 	if err != nil {
 		return nil, err
@@ -181,7 +183,7 @@ func NewHTTPClientsIfConfigured(config *service.Config) ([]service.Client, error
 	clients := make([]service.Client, 0)
 
 	httpClientToUse := &http.Client{
-		Timeout: config.DownstreamConnectionTimeout,
+		Timeout: config.DownstreamTimeout,
 	}
 
 	for _, serverURL := range config.H1DownstreamServers {

--- a/protocols/http.go
+++ b/protocols/http.go
@@ -81,13 +81,18 @@ func (c *httpClient) Close() error { return nil }
 
 func (c *httpClient) GetID() string { return c.id }
 
-func (c *httpClient) Send(_ context.Context, req *pb.TheRequest) (*pb.TheResponse, error) {
+func (c *httpClient) Send(ctx context.Context, req *pb.TheRequest) (*pb.TheResponse, error) {
 	json, err := marshallProtobufToJSON(req)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.clientForDownsteamServers.Post(c.serverURL, "application/json", strings.NewReader(json))
+	httpReq, err := http.NewRequest("POST", c.serverURL, strings.NewReader(json))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := c.clientForDownsteamServers.Do(httpReq.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/protocols/http_test.go
+++ b/protocols/http_test.go
@@ -1,6 +1,7 @@
 package protocols
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -214,7 +215,7 @@ func TestHTTPClient(t *testing.T) {
 			clientForDownsteamServers: http.DefaultClient,
 		}
 
-		actualProtoResponse, err := client.Send(expectedProtoRequest)
+		actualProtoResponse, err := client.Send(context.Background(), expectedProtoRequest)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -250,7 +251,7 @@ func TestHTTPClient(t *testing.T) {
 			clientForDownsteamServers: http.DefaultClient,
 		}
 
-		_, err := client.Send(expectedProtoRequest)
+		_, err := client.Send(context.Background(), expectedProtoRequest)
 		if err == nil {
 			t.Fatalf("Expecting error, got nothing")
 		}
@@ -279,7 +280,7 @@ func TestHTTPClient(t *testing.T) {
 			clientForDownsteamServers: http.DefaultClient,
 		}
 
-		_, err := client.Send(expectedProtoRequest)
+		_, err := client.Send(context.Background(), expectedProtoRequest)
 		if err == nil {
 			t.Fatalf("Expecting error, got nothing")
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -42,11 +42,11 @@ func (f *fireAndForgetClient) Close() error { return f.underlyingClient.Close() 
 func (f *fireAndForgetClient) GetID() string { return f.underlyingClient.GetID() }
 
 func (f *fireAndForgetClient) Send(ctx context.Context, req *pb.TheRequest) (*pb.TheResponse, error) {
-	go func(c Client, req *pb.TheRequest) {
+	go func(c Client, ctx context.Context, req *pb.TheRequest) {
 		log.Infof("Sending fire-and-forget request to [%s] for request UID [%s]", f.GetID(), req.RequestUID)
 		response, err := c.Send(ctx, req)
 		log.Infof("Response from fire-and-forget request to [%s] for request UID [%s] was: %s error %v", f.GetID(), req.RequestUID, response, err)
-	}(f.underlyingClient, req)
+	}(f.underlyingClient, ctx, req)
 
 	stubResponse := &pb.TheResponse{
 		Payload: fmt.Sprintf("Stub response for fire-and-forget request to [%s] for request UID [%s]", f.GetID(), req.RequestUID),

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -169,7 +169,7 @@ func TestFireAndForgetClient(t *testing.T) {
 			RequestUID: "some request UID goes here",
 		}
 
-		response, err := fnfClient.Send(request)
+		response, err := fnfClient.Send(context.Background(), request)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", expectedResponseToClose)
 		}
@@ -199,7 +199,7 @@ func TestFireAndForgetClient(t *testing.T) {
 			RequestUID: "some request UID goes here",
 		}
 
-		response, err := fnfClient.Send(request)
+		response, err := fnfClient.Send(context.Background(), request)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", errors.New("error to return on close"))
 		}

--- a/service/test_helper.go
+++ b/service/test_helper.go
@@ -22,7 +22,7 @@ func (m *MockClient) Close() error {
 
 func (m *MockClient) GetID() string { return m.IDToReturn }
 
-func (m *MockClient) Send(req *pb.TheRequest) (*pb.TheResponse, error) {
+func (m *MockClient) Send(_ context.Context, req *pb.TheRequest) (*pb.TheResponse, error) {
 	m.RequestReceived = req
 	if m.RequestInterceptor != nil {
 		m.RequestInterceptor(req)

--- a/strategies/broadcast_channel.go
+++ b/strategies/broadcast_channel.go
@@ -21,7 +21,7 @@ type BroadcastChannelStrategy struct {
 }
 
 // Do executes the request
-func (s *BroadcastChannelStrategy) Do(_ context.Context, req *pb.TheRequest) (*pb.TheResponse, error) {
+func (s *BroadcastChannelStrategy) Do(ctx context.Context, req *pb.TheRequest) (*pb.TheResponse, error) {
 	numberOfRequestsToMake := len(s.clients)
 	log.Infof("Starting broadcast to [%d] downstream services", numberOfRequestsToMake)
 	var wg sync.WaitGroup
@@ -32,7 +32,7 @@ func (s *BroadcastChannelStrategy) Do(_ context.Context, req *pb.TheRequest) (*p
 		go func(c service.Client) {
 			log.Infof("Making request to [%s]", c.GetID())
 			defer wg.Done()
-			clientResp, err := c.Send(req)
+			clientResp, err := c.Send(ctx, req)
 			if err != nil {
 				log.Errorf("Error when broadcasting request [%v] to client [%s]: %v", req, c.GetID(), err)
 				allResults <- fmt.Errorf("downstream server [%s] returned error: %v", c.GetID(), err)

--- a/strategies/point_to_point_channel.go
+++ b/strategies/point_to_point_channel.go
@@ -16,9 +16,9 @@ type PointToPointChannelStrategy struct {
 	clients []service.Client
 }
 
-func (s *PointToPointChannelStrategy) Do(_ context.Context, req *pb.TheRequest) (*pb.TheResponse, error) {
+func (s *PointToPointChannelStrategy) Do(ctx context.Context, req *pb.TheRequest) (*pb.TheResponse, error) {
 	client := s.clients[0]
-	resp, err := client.Send(req)
+	resp, err := client.Send(ctx, req)
 	return resp, err
 }
 


### PR DESCRIPTION
- Contexts now propagated between components
- Set deadline on gRPC client requests, based on downstream timeout
config
- More debug logging

Signed-off-by: Andrew Seigner <siggy@buoyant.io>